### PR TITLE
Use Github Commit Status API

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -59,7 +59,6 @@ app.get '/jenkins/post_build', (req, res) ->
   sha = req.param 'sha'
   job = req.param 'job'
   build = parseInt req.param 'build'
-  sha = req.param 'sha'
   user = req.param 'user'
   repo = req.param 'repo'
   succeeded = req.param('status') is 'success'

--- a/lib/github.coffee
+++ b/lib/github.coffee
@@ -149,7 +149,8 @@ class PullRequestCommenter extends GithubCommunicator
 
   updateCommitStatus: (pull, cb) =>
     state = if @succeeded then 'success' else 'failure'
-    comment = if @succeeded then @successComment() else @errorComment()
+    comment = if @succeeded then 'passed' else 'failed'
+    comment = 'The Jenkins build ' + comment
     @setCommitStatus @sha, state, @job_url, comment
     cb()
 

--- a/lib/github.coffee
+++ b/lib/github.coffee
@@ -79,7 +79,7 @@ class GithubCommunicator
 
   setCommitStatus: (sha, state, target, description) =>
     @post "/statuses/#{sha}", ({state: state, target_url: target, description: description}), (e, body) ->
-      log.info "Updating commit status to #{state}"
+      log.info "Updating commit status to '#{state}' for #{target}"
       log.warn e if e?
 
 
@@ -145,24 +145,24 @@ class PullRequestCommenter extends GithubCommunicator
   makePullComment: (pull, cb) =>
     comment = if @succeeded then @successComment() else @errorComment()
     @commentOnIssue pull.number, comment
-    cb()
+    cb null, pull
 
   updateCommitStatus: (pull, cb) =>
     state = if @succeeded then 'success' else 'failure'
     comment = if @succeeded then 'passed' else 'failed'
     comment = 'The Jenkins build ' + comment
     @setCommitStatus @sha, state, @job_url, comment
-    cb()
+    cb null, pull
 
   updateComments: (cb) =>
     async.waterfall [
       @getPulls
       @findMatchingPull
       @removePreviousPullComments
-      @makePullComment
       @updateCommitStatus
+      @makePullComment
     ], cb
 
-   
+
 exports.PullRequestCommenter = PullRequestCommenter
 


### PR DESCRIPTION
This uses Github's Commit Status API to update the commit status of the pull request on build completion, in addition to the existing behaviour of adding a comment. This adds a _status_ (success/failure) to the pull request, along with a basic description (could be improved!) and a link back to the Jenkins build. 

Further information on [Github's blog post](https://github.com/blog/1227-commit-status-api). Example below, although currently the description text will be 'The Jenkins build passed`

![commit status api](https://github-images.s3.amazonaws.com/skitch/status-001-20120830-161640.jpg)
