### PR TITLE
Allowing log file location and log level to be set via env configuration

### DIFF
--- a/env.coffee
+++ b/env.coffee
@@ -1,6 +1,8 @@
 
 # All constants in this block must be defined as env variables
 #
+exports.LOG_FILE = process.env.LOG_FILE || 'jennifer.log'
+exports.LOG_LEVEL = process.env.LOG_LEVEL || 'INFO'
 exports.JENKINS_URL = process.env.JENKINS_URL
 exports.JENKINS_USERNAME = process.env.JENKINS_USERNAME
 exports.JENKINS_PASSWORD = process.env.JENKINS_PASSWORD

--- a/lib/logging.coffee
+++ b/lib/logging.coffee
@@ -2,15 +2,17 @@
 # set up logging
 #
 
+env = require '../env'
+
 log4js = require('log4js')
 log4js.configure
     appenders: [
         # { type: 'console' }
-        { type: 'file', filename: 'jennifer.log', category: 'app' }
+        { type: 'file', filename: env.LOG_FILE, category: 'app' }
     ]
 
 log = log4js.getLogger 'app'
-log.setLevel 'INFO'
+log.setLevel env.LOG_LEVEL
 
 exports.log = log
          


### PR DESCRIPTION
Oh hey there, 

This was something we needed to be able to deploy jennifer, figured it might be helpful for others, as the directory that we pull the code to isn't writable by the user that runs the process. 

Just added LOG_LEVEL and LOG_FILE environment variables to make them configurable, there are also some defaults as well, so if you don't set those env vars jennifer still behaves in the same way she always has.
