### PR TITLE
Use emoji for build status comments

### DIFF
--- a/lib/github.coffee
+++ b/lib/github.coffee
@@ -97,20 +97,21 @@ class PullRequestCommenter extends GithubCommunicator
   IMAGE_PATH = "https://github.com/percolate/jennifer/raw/master/public/assets/images"
   PASSED_PATH = "#{IMAGE_PATH}/passed.png"
   FAILED_PATH = "#{IMAGE_PATH}/failed.png"
+  EMOJI = {"Failed":":no_entry:","Succeeded":":white_check_mark:"}
 
   constructor: (@sha, @job, @build, @user, @repo, @succeeded, @authToken) ->
     super @user, env.GITHUB_REPO, @authToken
     @job_url = "#{env.JENKINS_URL}/job/#{@job}/#{@build}"
 
   successComment: =>
-    @makeBuildReport "Succeeded", PASSED_PATH
+    @makeBuildReport "Succeeded"
 
   errorComment: =>
-    @makeBuildReport "Failed", FAILED_PATH
+    @makeBuildReport "Failed"
 
-  makeBuildReport: (status, image_path) =>
+  makeBuildReport: (status) =>
     report = "#{BUILDREPORT_MARKER}: `#{status}` "
-    report += "![stoplight](#{image_path} \"#{status}\") "
+    report += "#{EMOJI[status]}"
     report += " (#{@sha}, [build info](#{@job_url}))"
 
     report

--- a/lib/github.coffee
+++ b/lib/github.coffee
@@ -94,9 +94,6 @@ exports.GithubCommunicator = GithubCommunicator
 class PullRequestCommenter extends GithubCommunicator
 
   BUILDREPORT_MARKER = "**Build Status**"
-  IMAGE_PATH = "https://github.com/percolate/jennifer/raw/master/public/assets/images"
-  PASSED_PATH = "#{IMAGE_PATH}/passed.png"
-  FAILED_PATH = "#{IMAGE_PATH}/failed.png"
   EMOJI = {"Failed":":no_entry:","Succeeded":":white_check_mark:"}
 
   constructor: (@sha, @job, @build, @user, @repo, @succeeded, @authToken) ->


### PR DESCRIPTION
One more! This one was more a just a little project to get to know the code, take it if you want it! I just replaced the success and failure icons with the analogous emoji from github: :white_check_mark: and :no_entry: 

Some niceties of github emoji instead of the markdown image syntax:
- Github auto-posts comments to our hipchat, and the markdown syntax was just getting posted in there without being parsed at all which was sort of ugly:
  ![image](https://f.cloud.github.com/assets/1906/1246641/1b5aedb4-2ab0-11e3-97b7-e200400a5ea9.png)

I imagine there are similar issues with other service hooks that don't parse markdown.
- Emoji get displayed in the github newsfeed
- No more hardcoded image paths back to your repo
