### PR TITLE
encode branch names

### DIFF
--- a/lib/integration.coffee
+++ b/lib/integration.coffee
@@ -121,10 +121,10 @@ class GithubPrJenkinsIntegrator
   # create a Job name based on a branch name
   #
   makePrJobName: (branchName, prNum) =>
-      return "pr_#{prNum}_#{branchName}"
+      return "pr_#{prNum}_#{ encodeURIComponent branchName }"
 
   makeBranchFromJob: (jobName) =>
-      return jobName.replace /pr_\d+_/, ''
+      return decodeURIComponent jobName.replace /pr_\d+_/, ''
 
   # create a Jenkins job based on a PR
   # 


### PR DESCRIPTION
This fixes a bug if your branch name contains a `+` or something the job name will be incorrect.

It might probably mess up the displayed job name on jenkins if they are not decoded from uri components.
