### PR TITLE
Revert to non-hand status icons

### DIFF
--- a/lib/github.coffee
+++ b/lib/github.coffee
@@ -94,7 +94,7 @@ exports.GithubCommunicator = GithubCommunicator
 class PullRequestCommenter extends GithubCommunicator
 
   BUILDREPORT_MARKER = "**Build Status**"
-  EMOJI = {"Failed":":thumbsdown:","Succeeded":":thumbsup:","Pending":":hand:"}
+  EMOJI = {"Failed":":no_entry:","Succeeded":":white_check_mark:","Pending":":warning:"}
 
   constructor: (@sha, @job, @build, @user, @repo, @state, @authToken) ->
     super @user, env.GITHUB_REPO, @authToken


### PR DESCRIPTION
So as not to interfere with our approval logic in https://github.com/percolate/phaser

:no_entry: :white_check_mark: :warning: 
